### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2483,7 +2483,7 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "swarmd"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2540,7 +2540,7 @@ dependencies = [
 
 [[package]]
 name = "swarmd_instruments"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "sentry",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/swarmd-io/swarmd/compare/swarmd-v0.1.7...swarmd-v0.1.8) - 2023-11-29
+
+### Added
+- add a way to disable sentry
+
 ## [0.1.7](https://github.com/swarmd-io/swarmd/compare/swarmd-v0.1.6...swarmd-v0.1.7) - 2023-11-29
 
 ### Other

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swarmd"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 description = "Swarmd CLI"
 authors = ["Swarmd Team"]

--- a/lib/instruments/CHANGELOG.md
+++ b/lib/instruments/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/swarmd-io/swarmd/compare/swarmd_instruments-v0.1.1...swarmd_instruments-v0.1.2) - 2023-11-29
+
+### Added
+- add a way to disable sentry
+
 ## [0.1.1](https://github.com/swarmd-io/swarmd/compare/swarmd_instruments-v0.1.0...swarmd_instruments-v0.1.1) - 2023-11-29
 
 ### Other

--- a/lib/instruments/Cargo.toml
+++ b/lib/instruments/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://swarmd.io"
 repository = "https://github.com/swarmd_io/swarmd"
 documentation = "https://docs.swarmd.io"
 license = "MIT"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [features]


### PR DESCRIPTION
## 🤖 New release
* `swarmd`: 0.1.7 -> 0.1.8
* `swarmd_instruments`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `swarmd`
<blockquote>

## [0.1.8](https://github.com/swarmd-io/swarmd/compare/swarmd-v0.1.7...swarmd-v0.1.8) - 2023-11-29

### Added
- add a way to disable sentry
</blockquote>

## `swarmd_instruments`
<blockquote>

## [0.1.2](https://github.com/swarmd-io/swarmd/compare/swarmd_instruments-v0.1.1...swarmd_instruments-v0.1.2) - 2023-11-29

### Added
- add a way to disable sentry
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).