### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4135,7 +4135,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "swarmd"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4208,7 +4208,7 @@ dependencies = [
 
 [[package]]
 name = "swarmd_local_runtime"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "deno_ast",
  "deno_console",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.14](https://github.com/swarmd-io/swarmd/compare/swarmd-v0.1.13...swarmd-v0.1.14) - 2023-12-07
+
+### Other
+- update dependencies
+- update Dependencies and try to fix release ci for linux
+
 ## [0.1.13](https://github.com/swarmd-io/swarmd/compare/swarmd-v0.1.12...swarmd-v0.1.13) - 2023-12-06
 
 ### Added

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swarmd"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 description = "Swarmd CLI"
 authors = ["Swarmd Team"]

--- a/lib/swarmd_local_runtime/CHANGELOG.md
+++ b/lib/swarmd_local_runtime/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.3](https://github.com/swarmd-io/swarmd/compare/swarmd_local_runtime-v0.0.2...swarmd_local_runtime-v0.0.3) - 2023-12-07
+
+### Other
+- update Dependencies and try to fix release ci for linux
+
 ## [0.0.2](https://github.com/swarmd-io/swarmd/releases/tag/swarmd_local_runtime-v0.0.2) - 2023-12-06
 
 ### Other

--- a/lib/swarmd_local_runtime/Cargo.toml
+++ b/lib/swarmd_local_runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swarmd_local_runtime"
-version = "0.0.2"
+version = "0.0.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `swarmd`: 0.1.13 -> 0.1.14
* `swarmd_local_runtime`: 0.0.2 -> 0.0.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `swarmd`
<blockquote>

## [0.1.14](https://github.com/swarmd-io/swarmd/compare/swarmd-v0.1.13...swarmd-v0.1.14) - 2023-12-07

### Other
- update dependencies
- update Dependencies and try to fix release ci for linux
</blockquote>

## `swarmd_local_runtime`
<blockquote>

## [0.0.3](https://github.com/swarmd-io/swarmd/compare/swarmd_local_runtime-v0.0.2...swarmd_local_runtime-v0.0.3) - 2023-12-07

### Other
- update Dependencies and try to fix release ci for linux
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).