### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2642,9 +2642,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
@@ -4135,7 +4135,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "swarmd"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4208,7 +4208,7 @@ dependencies = [
 
 [[package]]
 name = "swarmd_local_runtime"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "deno_ast",
  "deno_console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ deno_websocket = "0.131"
 swarmd_instruments = { version = "0.1", path = "./lib/instruments" }
 swarmd_generated = { version = "0.1.1-alpha.2", path = "./lib/swarmd-generated" }
 swarmd_slug-rs = { version = "0.1.1-alpha.2", path = "./lib/slug-rs" }
-swarmd_local_runtime = { version = "0.0.3", path = "./lib/swarmd_local_runtime" }
+swarmd_local_runtime = { version = "0.0", path = "./lib/swarmd_local_runtime" }
 
 [profile.dev]
 panic = "abort"

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.15](https://github.com/swarmd-io/swarmd/compare/swarmd-v0.1.14...swarmd-v0.1.15) - 2023-12-07
+
+### Added
+- add socket upgrade
+
 ## [0.1.14](https://github.com/swarmd-io/swarmd/compare/swarmd-v0.1.13...swarmd-v0.1.14) - 2023-12-07
 
 ### Other

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swarmd"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 description = "Swarmd CLI"
 authors = ["Swarmd Team"]

--- a/lib/swarmd_local_runtime/CHANGELOG.md
+++ b/lib/swarmd_local_runtime/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.4](https://github.com/swarmd-io/swarmd/compare/swarmd_local_runtime-v0.0.3...swarmd_local_runtime-v0.0.4) - 2023-12-07
+
+### Added
+- add socket upgrade
+
 ## [0.0.3](https://github.com/swarmd-io/swarmd/compare/swarmd_local_runtime-v0.0.2...swarmd_local_runtime-v0.0.3) - 2023-12-07
 
 ### Other

--- a/lib/swarmd_local_runtime/Cargo.toml
+++ b/lib/swarmd_local_runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swarmd_local_runtime"
-version = "0.0.3"
+version = "0.0.4"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `swarmd`: 0.1.14 -> 0.1.15
* `swarmd_local_runtime`: 0.0.3 -> 0.0.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `swarmd`
<blockquote>

## [0.1.15](https://github.com/swarmd-io/swarmd/compare/swarmd-v0.1.14...swarmd-v0.1.15) - 2023-12-07

### Added
- add socket upgrade
</blockquote>

## `swarmd_local_runtime`
<blockquote>

## [0.0.4](https://github.com/swarmd-io/swarmd/compare/swarmd_local_runtime-v0.0.3...swarmd_local_runtime-v0.0.4) - 2023-12-07

### Added
- add socket upgrade
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).