### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ dependencies = [
  "futures-core",
  "memchr",
  "pin-project-lite",
- "tokio 1.35.0",
+ "tokio 1.35.1",
 ]
 
 [[package]]
@@ -254,7 +254,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-body 0.4.6",
- "hyper 0.14.27",
+ "hyper 0.14.28",
  "itoa",
  "matchit",
  "memchr",
@@ -267,7 +267,7 @@ dependencies = [
  "serde_path_to_error",
  "serde_urlencoded",
  "sync_wrapper",
- "tokio 1.35.0",
+ "tokio 1.35.1",
  "tower",
  "tower-layer",
  "tower-service",
@@ -935,7 +935,7 @@ dependencies = [
  "serde_v8",
  "smallvec 1.11.2",
  "sourcemap 7.0.1",
- "tokio 1.35.0",
+ "tokio 1.35.1",
  "url",
  "v8",
 ]
@@ -970,7 +970,7 @@ dependencies = [
  "sha2",
  "signature",
  "spki",
- "tokio 1.35.0",
+ "tokio 1.35.1",
  "uuid",
  "x25519-dalek",
 ]
@@ -989,7 +989,7 @@ dependencies = [
  "http",
  "reqwest",
  "serde",
- "tokio 1.35.0",
+ "tokio 1.35.1",
  "tokio-util",
 ]
 
@@ -1012,7 +1012,7 @@ dependencies = [
  "fly-accept-encoding",
  "http",
  "httparse",
- "hyper 0.14.27",
+ "hyper 0.14.28",
  "hyper 1.0.0-rc.4",
  "memmem",
  "mime",
@@ -1025,7 +1025,7 @@ dependencies = [
  "serde",
  "smallvec 1.11.2",
  "thiserror",
- "tokio 1.35.0",
+ "tokio 1.35.1",
  "tokio-util",
 ]
 
@@ -1066,8 +1066,8 @@ dependencies = [
  "pin-project",
  "rustls-tokio-stream",
  "serde",
- "socket2 0.5.5",
- "tokio 1.35.0",
+ "socket2",
+ "tokio 1.35.1",
  "trust-dns-proto",
  "trust-dns-resolver",
 ]
@@ -1109,7 +1109,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8a8f3722afd50e566ecfc783cc8a3a046bc4dd5eb45007431dfb2776aeb8993"
 dependencies = [
- "tokio 1.35.0",
+ "tokio 1.35.1",
 ]
 
 [[package]]
@@ -1137,7 +1137,7 @@ dependencies = [
  "flate2",
  "futures 0.3.29",
  "serde",
- "tokio 1.35.0",
+ "tokio 1.35.1",
  "uuid",
  "windows-sys 0.48.0",
 ]
@@ -1164,11 +1164,11 @@ dependencies = [
  "fastwebsockets",
  "h2",
  "http",
- "hyper 0.14.27",
+ "hyper 0.14.28",
  "once_cell",
  "rustls-tokio-stream",
  "serde",
- "tokio 1.35.0",
+ "tokio 1.35.1",
 ]
 
 [[package]]
@@ -1474,13 +1474,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17c35f166afb94b7f8e9449d0ad866daca111ba4053f3b1960bb480ca4382c63"
 dependencies = [
  "base64 0.21.5",
- "hyper 0.14.27",
+ "hyper 0.14.28",
  "pin-project",
  "rand",
  "sha1",
  "simdutf8",
  "thiserror",
- "tokio 1.35.0",
+ "tokio 1.35.1",
  "utf-8",
 ]
 
@@ -1804,7 +1804,7 @@ dependencies = [
  "http",
  "indexmap 2.1.0",
  "slab",
- "tokio 1.35.0",
+ "tokio 1.35.1",
  "tokio-util",
  "tracing",
 ]
@@ -1945,9 +1945,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.27"
+version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
 dependencies = [
  "bytes 1.5.0",
  "futures-channel",
@@ -1960,8 +1960,8 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
- "tokio 1.35.0",
+ "socket2",
+ "tokio 1.35.1",
  "tower-service",
  "tracing",
  "want",
@@ -1983,7 +1983,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "tokio 1.35.0",
+ "tokio 1.35.1",
  "tracing",
  "want",
 ]
@@ -1996,9 +1996,9 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http",
- "hyper 0.14.27",
+ "hyper 0.14.28",
  "rustls",
- "tokio 1.35.0",
+ "tokio 1.35.1",
  "tokio-rustls",
 ]
 
@@ -2009,9 +2009,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes 1.5.0",
- "hyper 0.14.27",
+ "hyper 0.14.28",
  "native-tls",
- "tokio 1.35.0",
+ "tokio 1.35.1",
  "tokio-native-tls",
 ]
 
@@ -2103,7 +2103,7 @@ dependencies = [
  "instant",
  "number_prefix",
  "portable-atomic",
- "tokio 1.35.0",
+ "tokio 1.35.1",
  "unicode-width",
 ]
 
@@ -2175,7 +2175,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.5",
+ "socket2",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -2189,9 +2189,9 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is-macro"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97707cce574453d050d7c53194bdd88f6e5e53d7c94d294f63f2511308af9867"
+checksum = "b75828adcb53122ef5ea649a39f50f82d94b754099bf6331b32e255e1891e8fb"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -3324,9 +3324,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.22"
+version = "0.11.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
+checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
 dependencies = [
  "async-compression",
  "base64 0.21.5",
@@ -3337,7 +3337,7 @@ dependencies = [
  "h2",
  "http",
  "http-body 0.4.6",
- "hyper 0.14.27",
+ "hyper 0.14.28",
  "hyper-rustls",
  "hyper-tls",
  "ipnet",
@@ -3355,7 +3355,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "system-configuration",
- "tokio 1.35.0",
+ "tokio 1.35.1",
  "tokio-native-tls",
  "tokio-rustls",
  "tokio-socks",
@@ -3529,7 +3529,7 @@ checksum = "897937c68ff975d028e8cc07bc887f2d5a9ec2bc952549f40db9a91dc557974c"
 dependencies = [
  "futures 0.3.29",
  "rustls",
- "tokio 1.35.0",
+ "tokio 1.35.1",
 ]
 
 [[package]]
@@ -3680,7 +3680,7 @@ checksum = "1a34ad8e4a86884ab42e9b8690e9343abdcfe5fa38a0318cfe1565ba9ad437b4"
 dependencies = [
  "either",
  "flate2",
- "hyper 0.14.27",
+ "hyper 0.14.28",
  "indicatif",
  "log",
  "quick-xml",
@@ -3718,9 +3718,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sentry"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b596ee5f4e76638de6063ca96fd3d923675416461fc7f1b77406dc2f32d1979"
+checksum = "ab18211f62fb890f27c9bb04861f76e4be35e4c2fcbfc2d98afa37aadebb16f1"
 dependencies = [
  "httpdate",
  "native-tls",
@@ -3731,15 +3731,15 @@ dependencies = [
  "sentry-debug-images",
  "sentry-panic",
  "sentry-tracing",
- "tokio 1.35.0",
+ "tokio 1.35.1",
  "ureq",
 ]
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6510a97162c288989a6310766bcadfc83ec98ad73121674463b055c42189e85"
+checksum = "cf018ff7d5ce5b23165a9cbfee60b270a55ae219bc9eebef2a3b6039356dd7e5"
 dependencies = [
  "backtrace",
  "once_cell",
@@ -3749,9 +3749,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e2552a4a578aade01bd44691e6805c32bac34fc918f1675739fbbf2add8460"
+checksum = "1d934df6f9a17b8c15b829860d9d6d39e78126b5b970b365ccbd817bc0fe82c9"
 dependencies = [
  "hostname",
  "libc",
@@ -3763,9 +3763,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb7a6ad833035f6b36db3e61e450643eec8a3c5f2839b8e41c74a73e57c6bae"
+checksum = "5e362d3fb1c5de5124bf1681086eaca7adf6a8c4283a7e1545359c729f9128ff"
 dependencies = [
  "once_cell",
  "rand",
@@ -3776,9 +3776,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bcd02214397892a3ec25372cc68c210d858f39314535f5d640bdf41294fd441"
+checksum = "d8bca420d75d9e7a8e54a4806bf4fa8a7e9a804e8f2ff05c7c80234168c6ca66"
 dependencies = [
  "findshlibs",
  "once_cell",
@@ -3787,9 +3787,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0866e2ba7615fe37e0e485f2373bf9dabbb255f82637b5fe47902095790bbbc9"
+checksum = "e0224e7a8e2bd8a32d96804acb8243d6d6e073fed55618afbdabae8249a964d8"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -3797,9 +3797,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53ef38653386354058f30b3c6d0bf764c59ee6270cd769ac4620a2d2fd60c8fe"
+checksum = "087bed8c616d176a9c6b662a8155e5f23b40dc9e1fa96d0bd5fb56e8636a9275"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -3809,9 +3809,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26342e85c6b3332273b820d5be6b93027fe991ded23a2aa6fb88a5a28c845c40"
+checksum = "fb4f0e37945b7a8ce7faebc310af92442e2d7c5aa7ef5b42fe6daa98ee133f65"
 dependencies = [
  "debugid",
  "hex",
@@ -3888,9 +3888,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
  "serde",
 ]
@@ -4105,16 +4105,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "socket2"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
@@ -4245,7 +4235,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "swarmd"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4280,7 +4270,7 @@ dependencies = [
  "swarmd_local_runtime",
  "swarmd_slug-rs",
  "thiserror",
- "tokio 1.35.0",
+ "tokio 1.35.1",
  "tokio-util",
  "toml 0.8.8",
  "tower-http",
@@ -4296,7 +4286,7 @@ dependencies = [
 
 [[package]]
 name = "swarmd_generated"
-version = "0.1.1-alpha.2"
+version = "0.1.1-alpha.3"
 dependencies = [
  "reqwest",
  "serde",
@@ -4335,11 +4325,11 @@ dependencies = [
  "deno_webidl",
  "deno_websocket",
  "fly-accept-encoding",
- "hyper 0.14.27",
+ "hyper 0.14.28",
  "insta",
  "log",
  "serde",
- "tokio 1.35.0",
+ "tokio 1.35.1",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -4809,9 +4799,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
+checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
 dependencies = [
  "deranged",
  "itoa",
@@ -4829,9 +4819,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
 dependencies = [
  "time-core",
 ]
@@ -4877,9 +4867,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.35.0"
+version = "1.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d45b238a16291a4e1584e61820b8ae57d696cc5015c459c229ccc6990cc1c"
+checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
 dependencies = [
  "backtrace",
  "bytes 1.5.0",
@@ -4889,7 +4879,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.5",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -4965,7 +4955,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
- "tokio 1.35.0",
+ "tokio 1.35.1",
 ]
 
 [[package]]
@@ -4994,7 +4984,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls",
- "tokio 1.35.0",
+ "tokio 1.35.1",
 ]
 
 [[package]]
@@ -5006,7 +4996,7 @@ dependencies = [
  "either",
  "futures-util",
  "thiserror",
- "tokio 1.35.0",
+ "tokio 1.35.1",
 ]
 
 [[package]]
@@ -5105,7 +5095,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project-lite",
- "tokio 1.35.0",
+ "tokio 1.35.1",
  "tracing",
 ]
 
@@ -5162,7 +5152,7 @@ dependencies = [
  "futures-util",
  "pin-project",
  "pin-project-lite",
- "tokio 1.35.0",
+ "tokio 1.35.1",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5329,7 +5319,7 @@ dependencies = [
  "smallvec 1.11.2",
  "thiserror",
  "tinyvec",
- "tokio 1.35.0",
+ "tokio 1.35.1",
  "tracing",
  "url",
 ]
@@ -5350,7 +5340,7 @@ dependencies = [
  "serde",
  "smallvec 1.11.2",
  "thiserror",
- "tokio 1.35.0",
+ "tokio 1.35.1",
  "tracing",
  "trust-dns-proto",
 ]
@@ -5996,9 +5986,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.28"
+version = "0.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c830786f7720c2fd27a1a0e27a709dbd3c4d009b56d098fc742d4f4eab91fe2"
+checksum = "9b5c3db89721d50d0e2a673f5043fc4722f76dcc352d7b1ab8b8288bed4ed2c5"
 dependencies = [
  "memchr",
 ]

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.21](https://github.com/swarmd-io/swarmd/compare/swarmd-v0.1.20...swarmd-v0.1.21) - 2023-12-20
+
+### Added
+- remove template folder when creating a new project
+
+### Other
+- show route when deploying
+
 ## [0.1.20](https://github.com/swarmd-io/swarmd/compare/swarmd-v0.1.19...swarmd-v0.1.20) - 2023-12-17
 
 ### Added

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swarmd"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2021"
 description = "Swarmd CLI"
 authors = ["Swarmd Team"]

--- a/lib/swarmd-generated/CHANGELOG.md
+++ b/lib/swarmd-generated/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1-alpha.3](https://github.com/swarmd-io/swarmd/compare/swarmd_generated-v0.1.1-alpha.2...swarmd_generated-v0.1.1-alpha.3) - 2023-12-20
+
+### Other
+- show route when deploying

--- a/lib/swarmd-generated/Cargo.toml
+++ b/lib/swarmd-generated/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swarmd_generated"
-version = "0.1.1-alpha.2"
+version = "0.1.1-alpha.3"
 authors = ["anthony@brevz.io"]
 description = "# Introduction  blblbllb "
 homepage = "https://swarmd.io"


### PR DESCRIPTION
## 🤖 New release
* `swarmd`: 0.1.20 -> 0.1.21
* `swarmd_generated`: 0.1.1-alpha.2 -> 0.1.1-alpha.3 (⚠️ API breaking changes)

### ⚠️ `swarmd_generated` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.24.2/src/lints/constructible_struct_adds_field.ron

Failed in:
  field PublishWorkerResponse.route in /tmp/.tmpiaw3JX/swarmd/lib/swarmd-generated/src/models/publish_worker_response.rs:16
  field PublishWorkerResponse.route in /tmp/.tmpiaw3JX/swarmd/lib/swarmd-generated/src/models/publish_worker_response.rs:16

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.24.2/src/lints/method_parameter_count_changed.ron

Failed in:
  swarmd_generated::models::publish_worker_response::PublishWorkerResponse::new now takes 2 parameters instead of 1, in /tmp/.tmpiaw3JX/swarmd/lib/swarmd-generated/src/models/publish_worker_response.rs:20
  swarmd_generated::models::PublishWorkerResponse::new now takes 2 parameters instead of 1, in /tmp/.tmpiaw3JX/swarmd/lib/swarmd-generated/src/models/publish_worker_response.rs:20
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `swarmd`
<blockquote>

## [0.1.21](https://github.com/swarmd-io/swarmd/compare/swarmd-v0.1.20...swarmd-v0.1.21) - 2023-12-20

### Added
- remove template folder when creating a new project

### Other
- show route when deploying
</blockquote>

## `swarmd_generated`
<blockquote>

## [0.1.1-alpha.3](https://github.com/swarmd-io/swarmd/compare/swarmd_generated-v0.1.1-alpha.2...swarmd_generated-v0.1.1-alpha.3) - 2023-12-20

### Other
- show route when deploying
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).